### PR TITLE
Fix WATCH for keys that do not yet exist

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -200,7 +200,7 @@ exports.Backend = function() {
 
     if (!entry || entry.expire < Date.now()) {
       delete state[key];
-      delrev[key] =++rev;
+      delrev[key] = rev;
       entry = null;
     }
     else if (!(entry.value instanceof VALID_TYPE))

--- a/test.js
+++ b/test.js
@@ -452,6 +452,21 @@ process.stdout.write ( 'testing fakeredis ...\n\n' );
 
 ( function ()
 {
+    var multi,
+        redis  = fake.createClient ( "transactions-1" ),
+        redis2 = fake.createClient ( "transactions-1" );
+
+    redis.WATCH ( "abc" );
+    redis.GET( "abc" );
+    multi = redis.MULTI ();
+    multi.SET ( "abc", "dfgdfg" );
+    multi.exec ( test("EXEC succeeds", null, ['OK'] ) );
+    redis.GET ( "abc", test ( "GET succeeds", null, "dfgdfg" ) );
+}
+() );
+
+( function ()
+{
     var client = fake.createClient (), set_size = 1000;
 
     client.sadd("bigset", "a member");
@@ -1025,7 +1040,7 @@ function countTests() {
 }
 
 var NUM_TESTS = countTests();
-if (NUM_TESTS !== 253)
+if (NUM_TESTS !== 255)
     throw new Error("Test count is off: " + NUM_TESTS);
 
 var doexit = false;


### PR DESCRIPTION
Previous to this change, every read command for a key that does not exist increments a revision counter. This caused certain transactions fail when they should not, such as this one:

```
WATCH key // rev 0
GET key   // ++rev
MULTI
SET key
EXEC      // check 0 === 1, fail
```

I've added a test that demonstrates the issue, and a simple change that fixes this use case.
