### PR TITLE
Document fast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ because you can run as many tests in parallel as you wish,
 and that's also why you'll generally be naming your clients
 in a way that ensures tests don't collide.
 
+By default fakeredis simulates network latency
+to help you discover race-conditions when testing multi-client setups.
+Network latency can be disabled using the .fast option:
 
+```javascript
+var client = require("fakeredis").createClient(port, host, {
+    fast : true
+});
+```
 
 ## Intended differences from a true Redis
 


### PR DESCRIPTION
Enabling/disabling network latency is a useful feature to document. 

I recently set the fast option to true on the project I'm working on (no network latency required) which dramatically improved the performance of the tests. 