### PR TITLE
Fix: pass errors in EXEC reply array

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -429,7 +429,7 @@ exports.Connection = function(backend, minLatency, maxLatency) {
 
   function pushReply(err, data) {
     /*jshint validthis:true*/
-    this.push(fdata(data));
+    this.push(err ||fdata(data));
   }
 
 


### PR DESCRIPTION
There is a difference between `redis` and `fakeredis` handling of errors during MULTI-EXEC. `redis` (real) client puts error into array with replies while `fakeredis` ignores it and returns `null` in case of error.