### PR TITLE
Override redisClient duplicate method with redis createClient

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,6 +45,18 @@ exports.createClient = function(port, host, options) {
 
   cl.duplicate = exports.createClient;
 
+  var real_on = cl.on;
+  cl.on = function(eventName, callback) {
+    switch(eventName) {
+      case 'end':
+      case 'ready':
+        setTimeout(callback.bind(cl), 0);
+        break;
+      default:
+        real_on.apply(cl, arguments);
+    }
+  };
+
   // Replace the mocked create_stream function again with the original one
   RedisClient.prototype.create_stream = real_create_stream;
 

--- a/main.js
+++ b/main.js
@@ -43,6 +43,8 @@ exports.createClient = function(port, host, options) {
 
   var cl = new RedisClient(/* options */)
 
+  cl.duplicate = exports.createClient;
+
   // Replace the mocked create_stream function again with the original one
   RedisClient.prototype.create_stream = real_create_stream;
 


### PR DESCRIPTION
Fixes issue #48. We noticed that the duplicate method was calling out to 127.0.0.1. We pointed the instance of RedisClient's duplicate method at fakeredis' createClient method.
